### PR TITLE
Add anime and video game quizzes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# emoji_quiz
-a daily quiz website using html, css, js. it is inspired by Wordl and will have different types and genres of quized (movies, games, anime, natur, random, etc...) 
+# Emoji Quiz
+
+This project is a lightweight website that offers a daily emoji quiz inspired by **Wordle**. Each day you are presented with a set of emojis hinting at a word or phrase. You have six attempts to guess the answer. Begin by selecting a category such as **Movies**, **Anime**, **Video Games**, **Other**, or the new **Daily Challenge** mode to see the quiz of the day.
+
+The **Daily Challenge** presents five random puzzles with just three lives in total. Use the Hint button if you get stuck to reveal the category of the current puzzle.
+
+## Running Locally
+
+1. Clone this repository.
+2. Open `index.html` in your browser.
+
+No build tools are required; the site is plain HTML, CSS and JavaScript.
+
+## Contributing
+Feel free to submit new quizzes or improvements via pull request.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Emoji Quiz</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Daily Emoji Quiz</h1>
+        <p>Guess the word or phrase represented by the emojis. You have six attempts.</p>
+    </header>
+    <main>
+        <section id="category-selection">
+            <h2>Select a category</h2>
+            <button class="category-btn" data-category="Movies">Movies</button>
+            <button class="category-btn" data-category="Anime">Anime</button>
+            <button class="category-btn" data-category="Video Games">Video Games</button>
+            <button class="category-btn" data-category="Other">Other</button>
+            <button class="category-btn" data-category="Daily Challenge">Daily Challenge</button>
+        </section>
+
+        <section id="quiz-section" hidden>
+            <div id="emoji-display" class="emoji"></div>
+            <input type="text" id="guess-input" placeholder="Your guess" autofocus>
+            <button id="guess-btn">Guess</button>
+            <button id="hint-btn" type="button">Hint</button>
+            <p id="lives" class="lives"></p>
+            <p id="message"></p>
+        </section>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,136 @@
+const quizzes = [
+    { emoji: '🎬🚀', answer: 'Star Wars', category: 'Movies' },
+    { emoji: '🕷️🧑', answer: 'Spider Man', category: 'Movies' },
+    { emoji: '🐉🔥', answer: 'Dragon Fire', category: 'Movies' },
+    { emoji: '🍕🐢', answer: 'Teenage Mutant Ninja Turtles', category: 'Movies' },
+    { emoji: '👑🧊', answer: 'Frozen', category: 'Movies' },
+    { emoji: '⚡️🧙', answer: 'Harry Potter', category: 'Movies' },
+    { emoji: '🌋🦎', answer: 'Godzilla', category: 'Movies' },
+    { emoji: '🐯👑', answer: 'Tiger King', category: 'Movies' },
+
+    { emoji: '🍙👹', answer: 'Demon Slayer', category: 'Anime' },
+    { emoji: '⚡️🍥', answer: 'Naruto', category: 'Anime' },
+    { emoji: '👊🏫', answer: 'My Hero Academia', category: 'Anime' },
+
+    { emoji: '🍄🧑', answer: 'Super Mario', category: 'Video Games' },
+    { emoji: '🔫👾', answer: 'Space Invaders', category: 'Video Games' },
+    { emoji: '🧟🔫', answer: 'Resident Evil', category: 'Video Games' },
+
+    { emoji: '⛺🔥', answer: 'campfire', category: 'Other' },
+    { emoji: '🍔🍟', answer: 'fast food', category: 'Other' }
+];
+
+let attempts = 0;
+const maxAttempts = 6;
+let lives = 3;
+let challengeQuizzes = [];
+let challengeIndex = 0;
+let inDailyChallenge = false;
+
+function getQuizOfTheDay(category) {
+    const today = new Date();
+    const start = new Date(today.getFullYear(), 0, 0);
+    const diff = today - start;
+    const dayOfYear = Math.floor(diff / 86400000); // ms per day
+    const qs = quizzes.filter(q => q.category === category);
+    return qs[dayOfYear % qs.length];
+}
+
+function shuffle(arr) {
+    return arr.sort(() => Math.random() - 0.5);
+}
+
+function startDailyChallenge() {
+    inDailyChallenge = true;
+    lives = 3;
+    challengeQuizzes = shuffle([...quizzes]).slice(0, 5);
+    challengeIndex = 0;
+    document.getElementById('category-selection').hidden = true;
+    document.getElementById('quiz-section').hidden = false;
+    showChallengeQuestion();
+}
+
+function showChallengeQuestion() {
+    currentQuiz = challengeQuizzes[challengeIndex];
+    document.getElementById('emoji-display').textContent = currentQuiz.emoji;
+    message.textContent = '';
+    input.disabled = false;
+    input.value = '';
+    livesDisplay.textContent = `Lives: ${lives}`;
+    input.focus();
+}
+
+let currentQuiz = null;
+
+const input = document.getElementById('guess-input');
+const message = document.getElementById('message');
+const hintBtn = document.getElementById('hint-btn');
+const livesDisplay = document.getElementById('lives');
+
+function startQuiz(category) {
+    if (category === 'Daily Challenge') {
+        startDailyChallenge();
+        return;
+    }
+
+    attempts = 0;
+    inDailyChallenge = false;
+    currentQuiz = getQuizOfTheDay(category);
+    document.getElementById('emoji-display').textContent = currentQuiz.emoji;
+    message.textContent = '';
+    input.disabled = false;
+    input.value = '';
+    livesDisplay.textContent = '';
+    document.getElementById('quiz-section').hidden = false;
+    document.getElementById('category-selection').hidden = true;
+    input.focus();
+}
+
+document.querySelectorAll('.category-btn').forEach(btn => {
+    btn.addEventListener('click', () => startQuiz(btn.dataset.category));
+});
+
+document.getElementById('guess-btn').addEventListener('click', () => {
+    const guess = input.value.trim().toLowerCase();
+    if (!guess) return;
+    if (inDailyChallenge) {
+        if (guess === currentQuiz.answer.toLowerCase()) {
+            message.textContent = 'Correct!';
+            challengeIndex++;
+            if (challengeIndex >= challengeQuizzes.length) {
+                message.textContent = 'You completed the challenge!';
+                input.disabled = true;
+            } else {
+                showChallengeQuestion();
+            }
+        } else {
+            lives--;
+            if (lives <= 0) {
+                message.textContent = `Out of lives! The answer was "${currentQuiz.answer}"`;
+                input.disabled = true;
+            } else {
+                message.textContent = `Wrong! Lives left: ${lives}`;
+                livesDisplay.textContent = `Lives: ${lives}`;
+            }
+        }
+    } else {
+        attempts++;
+        if (guess === currentQuiz.answer.toLowerCase()) {
+            message.textContent = `Correct! The answer was "${currentQuiz.answer}"`;
+            input.disabled = true;
+        } else if (attempts >= maxAttempts) {
+            message.textContent = `Out of attempts! The answer was "${currentQuiz.answer}"`;
+            input.disabled = true;
+        } else {
+            const remaining = maxAttempts - attempts;
+            message.textContent = `Wrong! Attempts left: ${remaining}`;
+        }
+    }
+    input.value = '';
+});
+
+hintBtn.addEventListener('click', () => {
+    if (currentQuiz) {
+        message.textContent = `Hint: ${currentQuiz.category}`;
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+    background-color: #f5f5f5;
+}
+
+header {
+    background-color: #222;
+    color: #fff;
+    padding: 1em 0;
+}
+
+main {
+    margin-top: 2em;
+}
+
+#category-selection button {
+    margin: 0.5em;
+    padding: 0.5em 1em;
+    font-size: 1rem;
+}
+
+.emoji {
+    font-size: 3rem;
+    margin-bottom: 1em;
+}
+
+#guess-input {
+    padding: 0.5em;
+    font-size: 1rem;
+    width: 200px;
+}
+
+#guess-btn {
+    padding: 0.5em 1em;
+    font-size: 1rem;
+    margin-left: 0.5em;
+}
+
+#hint-btn {
+    padding: 0.5em 1em;
+    font-size: 1rem;
+    margin-left: 0.5em;
+}
+
+.lives {
+    margin-top: 0.5em;
+    font-weight: bold;
+}
+
+#message {
+    margin-top: 1em;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- expand README introduction with example categories
- add Anime and Video Games buttons in the category selector
- provide new quiz data for Anime and Video Games topics
- add Daily Challenge mode with hints and lives

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878963cd17c832ca8e8335bc71547a4